### PR TITLE
full initializer-list constructor

### DIFF
--- a/include/xframe/xvariable.hpp
+++ b/include/xframe/xvariable.hpp
@@ -63,6 +63,7 @@ namespace xf
         using data_closure_type = typename base_type::data_closure_type;
         using coordinate_map = typename base_type::coordinate_map;
         using coordinate_initializer = typename base_type::coordinate_initializer;
+        using dimension_list = typename base_type::dimension_list;
         using temporary_type = typename semantic_base::temporary_type;
 
         using expression_tag = xvariable_expression_tag;
@@ -71,23 +72,18 @@ namespace xf
 
         template <class C, class DM, class = enable_xvariable<C, DM>>
         explicit xvariable(C&& coords, DM&& dims);
-
-        template <class DM>
-        explicit xvariable(const coordinate_map& coords, DM&& dims);
-
-        template <class DM>
-        explicit xvariable(coordinate_map&& coords, DM&& dims);
-
+        explicit xvariable(const coordinate_map& coords, const dimension_list& dims);
+        explicit xvariable(coordinate_map&& coords, dimension_list&& dims);
         explicit xvariable(coordinate_initializer coords);
 
         template <class D, class C, class DM, class = enable_xvariable_t<C, DM>>
         explicit xvariable(D&& data, C&& coords, DM&& dims);
 
-        template <class D, class DM>
-        explicit xvariable(D&& data, const coordinate_map& coords, DM&& dims);
+        template <class D>
+        explicit xvariable(D&& data, const coordinate_map& coords, const dimension_list& dims);
 
-        template <class D, class DM>
-        explicit xvariable(D&& data, coordinate_map&& coords, DM&& dims);
+        template <class D>
+        explicit xvariable(D&& data, coordinate_map&& coords, dimension_list&& dims);
 
         template <class D>
         explicit xvariable(D&& data, coordinate_initializer coords);
@@ -155,17 +151,15 @@ namespace xf
     }
 
     template <class CCT, class ECT>
-    template <class DM>
-    inline xvariable<CCT, ECT>::xvariable(const coordinate_map& coords, DM&& dims)
-        : base_type(coords, std::forward<DM>(dims)),
+    inline xvariable<CCT, ECT>::xvariable(const coordinate_map& coords, const dimension_list& dims)
+        : base_type(coords, dims),
           m_data(base_type::compute_shape())
     {
     }
 
     template <class CCT, class ECT>
-    template <class DM>
-    inline xvariable<CCT, ECT>::xvariable(coordinate_map&& coords, DM&& dims)
-        : base_type(std::move(coords), std::forward<DM>(dims)),
+    inline xvariable<CCT, ECT>::xvariable(coordinate_map&& coords, dimension_list&& dims)
+        : base_type(std::move(coords), std::move(dims)),
           m_data(base_type::compute_shape())
     {
     }
@@ -186,17 +180,17 @@ namespace xf
     }
 
     template <class CCT, class ECT>
-    template <class D, class DM>
-    inline xvariable<CCT, ECT>::xvariable(D&& data, const coordinate_map& coords, DM&& dims)
-        : base_type(coords, std::forward<DM>(dims)),
+    template <class D>
+    inline xvariable<CCT, ECT>::xvariable(D&& data, const coordinate_map& coords, const dimension_list& dims)
+        : base_type(coords, dims),
           m_data(std::forward<D>(data))
     {
     }
 
     template <class CCT, class ECT>
-    template <class D, class DM>
-    inline xvariable<CCT, ECT>::xvariable(D&& data, coordinate_map&& coords, DM&& dims)
-        : base_type(std::move(coords), std::forward<DM>(dims)),
+    template <class D>
+    inline xvariable<CCT, ECT>::xvariable(D&& data, coordinate_map&& coords, dimension_list&& dims)
+        : base_type(std::move(coords), std::move(dims)),
           m_data(std::forward<D>(data))
     {
     }

--- a/include/xframe/xvariable_base.hpp
+++ b/include/xframe/xvariable_base.hpp
@@ -168,14 +168,10 @@ namespace xf
         xvariable_base() = default;
         xvariable_base(coordinate_initializer coords);
         
-        template <class C, class DM>
+        template <class C, class DM, class = enable_xvariable<C, DM>>
         xvariable_base(C&& coords, DM&& dims);
-
-        template <class DM>
-        xvariable_base(const coordinate_map& coords, DM&& dims);
-
-        template <class DM>
-        xvariable_base(coordinate_map&& coords, DM&& dims);
+        xvariable_base(const coordinate_map& coords, const dimension_list& dims);
+        xvariable_base(coordinate_map&& coords, dimension_list&& dims);
 
         ~xvariable_base() = default;
 
@@ -224,7 +220,7 @@ namespace xf
      *********************************/
 
     template <class D>
-    template <class C, class DM>
+    template <class C, class DM, class>
     inline xvariable_base<D>::xvariable_base(C&& coords, DM&& dims)
         : coordinate_base(std::forward<C>(coords), std::forward<DM>(dims))
     {
@@ -239,16 +235,14 @@ namespace xf
     }
 
     template <class D>
-    template <class DM>
-    inline xvariable_base<D>::xvariable_base(const coordinate_map& coords, DM&& dims)
-        : xvariable_base(coordinate_type(coords), std::forward<DM>(dims))
+    inline xvariable_base<D>::xvariable_base(const coordinate_map& coords, const dimension_list& dims)
+        : xvariable_base(coordinate_type(coords), dimension_type(dims))
     {
     }
 
     template <class D>
-    template <class DM>
-    inline xvariable_base<D>::xvariable_base(coordinate_map&& coords, DM&& dims)
-        : xvariable_base(coordinate_type(std::move(coords)), std::forward<DM>(dims))
+    inline xvariable_base<D>::xvariable_base(coordinate_map&& coords, dimension_list&& dims)
+        : xvariable_base(coordinate_type(std::move(coords)), dimension_type(std::move(dims)))
     {
     }
 

--- a/test/test_xvariable.cpp
+++ b/test/test_xvariable.cpp
@@ -42,8 +42,8 @@ namespace xf
         variable_type::coordinate_map m2(m);
 
         data_type d = make_test_data();
-        dimension_type dim_map = {"abscissa", "ordinate"};
-        dimension_type dim_map2(dim_map);
+        dimension_type::label_list dim_map = {"abscissa", "ordinate"};
+        dimension_type::label_list dim_map2(dim_map);
         auto v2 = variable_type(d, m, dim_map);
         auto v3 = variable_type(d, std::move(m), std::move(dim_map));
 


### PR DESCRIPTION
@martinRenou This should allow to initialize `xvariable` with initializer lists only (even for the dimension mapping).