### PR TITLE
Add get_labels function for axes

### DIFF
--- a/include/xframe/xaxis_variant.hpp
+++ b/include/xframe/xaxis_variant.hpp
@@ -592,7 +592,7 @@ namespace xf
     }
 
     template <class LB, class L, class T, class MT>
-    auto get_labels(xaxis_variant<L, T, MT> axis_variant)
+    auto get_labels(const xaxis_variant<L, T, MT>& axis_variant) -> const typename xaxis<LB, T, MT>::label_list&
     {
         using label_list = typename xaxis<LB, T, MT>::label_list;
 

--- a/include/xframe/xaxis_variant.hpp
+++ b/include/xframe/xaxis_variant.hpp
@@ -590,6 +590,16 @@ namespace xf
     {
         return lhs.less_than(rhs);
     }
+
+    template <class LB, class L, class T, class MT>
+    auto get_labels(xaxis_variant<L, T, MT> axis_variant)
+    {
+        using label_list = typename xaxis<LB, T, MT>::label_list;
+
+        const label_list& labels = axis_variant.template labels<LB>();
+
+        return labels;
+    }
 }
 
 #endif

--- a/include/xframe/xnamed_axis.hpp
+++ b/include/xframe/xnamed_axis.hpp
@@ -96,7 +96,7 @@ namespace xf
     }
 
     template <class LB, class K, class T>
-    auto get_labels(xnamed_axis<K, T> n_axis)
+    auto get_labels(const xnamed_axis<K, T>& n_axis) -> const typename xaxis<LB, T>::label_list&
     {
         return get_labels<LB>(n_axis.axis());
     }

--- a/include/xframe/xnamed_axis.hpp
+++ b/include/xframe/xnamed_axis.hpp
@@ -80,7 +80,7 @@ namespace xf
     {
         static_assert(is_axis<std::decay_t<A>>::value, "axis must be an axis type");
 
-        using T = typename A::mapped_type;
+        using T = typename std::decay_t<A>::mapped_type;
 
         return xnamed_axis<K, T>(name, axis);
     }
@@ -90,9 +90,15 @@ namespace xf
     {
         static_assert(is_axis<std::decay_t<A>>::value, "axis must be an axis type");
 
-        using T = typename A::mapped_type;
+        using T = typename std::decay_t<A>::mapped_type;
 
         return xnamed_axis<const char*, T>(name, axis);
+    }
+
+    template <class LB, class K, class T>
+    auto get_labels(xnamed_axis<K, T> n_axis)
+    {
+        return get_labels<LB>(n_axis.axis());
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(XFRAME_TESTS
     test_fixture_view.hpp
     test_xaxis.cpp
     test_xaxis_default.cpp
+    test_xaxis_variant.cpp
     test_xaxis_view.cpp
     test_xcoordinate.cpp
     test_xcoordinate_view.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(XFRAME_TESTS
     test_xdimension.cpp
     test_xdynamic_variable.cpp
     test_xframe_utils.cpp
+    test_xnamed_axis.cpp
     test_xsequence_view.cpp
     test_xvariable.cpp
     test_xvariable_assign.cpp

--- a/test/test_xaxis_variant.cpp
+++ b/test/test_xaxis_variant.cpp
@@ -1,0 +1,68 @@
+/***************************************************************************
+* Copyright (c) 2017, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <cstddef>
+#include <vector>
+#include "gtest/gtest.h"
+
+#include "xframe/xframe_config.hpp"
+#include "xframe/xaxis_variant.hpp"
+
+namespace xf
+{
+    using axis_variant_type = xaxis_variant<DEFAULT_LABEL_LIST, std::size_t>;
+
+    TEST(xaxis_variant, get_labels)
+    {
+        auto a = axis_variant_type(axis(56));
+        auto labels = get_labels<int>(a);
+
+        EXPECT_EQ(0u, labels[0]);
+        EXPECT_EQ(56u, labels.size());
+    }
+
+    TEST(xaxis_variant, size)
+    {
+        auto a = axis_variant_type(axis(56));
+        EXPECT_EQ(56u, a.size());
+        EXPECT_FALSE(a.empty());
+
+        auto a2 = axis_variant_type(axis(0));
+        EXPECT_EQ(0u, a2.size());
+        EXPECT_TRUE(a2.empty());
+    }
+
+    TEST(xaxis_variant, is_sorted)
+    {
+        auto a = axis_variant_type(axis(36, 56, 2));
+        EXPECT_TRUE(a.is_sorted());
+    }
+
+    TEST(xaxis_variant, contains)
+    {
+        auto a = axis_variant_type(axis(36));
+        EXPECT_TRUE(a.contains(0));
+        EXPECT_TRUE(a.contains(15));
+        EXPECT_TRUE(a.contains(35));
+        EXPECT_FALSE(a.contains(36));
+        EXPECT_FALSE(a.contains(126));
+        EXPECT_FALSE(a.contains(-2));
+    }
+
+    TEST(xaxis_variant, access)
+    {
+        auto a = axis_variant_type(axis(3));
+        auto a0 = a[0];
+        auto a1 = a[1];
+        auto a2 = a[2];
+        EXPECT_EQ(0u, a0);
+        EXPECT_EQ(1u, a1);
+        EXPECT_EQ(2u, a2);
+        EXPECT_THROW(a[3], std::out_of_range);
+    }
+}

--- a/test/test_xnamed_axis.cpp
+++ b/test/test_xnamed_axis.cpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+* Copyright (c) 2017, Johan Mabille, Sylvain Corlay and Wolf Vollprecht    *
+*                                                                          *
+* Distributed under the terms of the BSD 3-Clause License.                 *
+*                                                                          *
+* The full license is in the file LICENSE, distributed with this software. *
+****************************************************************************/
+
+#include <string>
+#include "gtest/gtest.h"
+
+#include "xframe/xnamed_axis.hpp"
+
+namespace xf
+{
+    TEST(xnamed_axis, get_labels)
+    {
+        auto a = axis(56);
+        auto n_a = named_axis("axis_a", a);
+        auto labels = get_labels<int>(n_a);
+
+        EXPECT_EQ(labels, a.labels());
+        EXPECT_EQ(0u, labels[0]);
+        EXPECT_EQ(56u, labels.size());
+    }
+
+    TEST(xnamed_axis, name)
+    {
+        auto a = axis(56);
+        auto n_a = named_axis("axis_a", a);
+        EXPECT_EQ("axis_a", n_a.name());
+    }
+}


### PR DESCRIPTION
The get_labels function is a helper function for getting the labels of an xaxis_variant or an xnamed_axis. Instead of using:
```c++
auto labels = axis_variant.template labels<std::string>();
```
The user can now use:
```c++
auto labels = get_labels<std::string>(axis_variant);
```