### PR TITLE
Fix axis function

### DIFF
--- a/include/xframe/xaxis.hpp
+++ b/include/xframe/xaxis.hpp
@@ -609,6 +609,12 @@ namespace xf
     {
         return xaxis<L, T>(init);
     }
+
+    template <class T = std::size_t>
+    inline auto axis(std::initializer_list<const char*> init) noexcept
+    {
+        return xaxis<xtl::xfixed_string<55>, T>(init.begin(), init.end());
+    }
 }
 
 #endif


### PR DESCRIPTION
Fix `axis` function for `std::initializer_list` containing `const char*`, so it's now possible to create an axis like that:

```c++
auto time_axis = axis({"yesterday", "today", "tomorrow"});
```