### PR TITLE
WIP: nearest neighbor lookup selection

### DIFF
--- a/include/xframe/xaxis.hpp
+++ b/include/xframe/xaxis.hpp
@@ -9,6 +9,8 @@
 #ifndef XFRAME_XAXIS_HPP
 #define XFRAME_XAXIS_HPP
 
+extern double global_tolerance;
+
 #include <initializer_list>
 #include <iterator>
 #include <algorithm>
@@ -412,6 +414,24 @@ namespace xf
     template <class L, class T, class MT>
     inline auto xaxis<L, T, MT>::operator[](const key_type& key) const -> mapped_type
     {
+        if constexpr (std::is_floating_point<key_type>::value)
+        {
+            if (global_tolerance > 0.)
+            {
+                double smallest;
+                int position = -1;
+                for (const auto& it: m_index)
+                {
+                    double diff = fabs(double(it.first) - key);
+                    if ((diff <= global_tolerance) && ((position < 0) || (diff < smallest)))
+                    {
+                        smallest = diff;
+                        position = it.second;
+                    }
+                }
+                return position >= 0 ? position : m_index.at(key);
+            }
+        }
         return m_index.at(key);
     }
     //@}

--- a/include/xframe/xvariable.hpp
+++ b/include/xframe/xvariable.hpp
@@ -15,6 +15,8 @@
 #include "xvariable_base.hpp"
 #include "xvariable_math.hpp"
 
+double global_tolerance = 0.;
+
 namespace xf
 {
     /***********************

--- a/include/xframe/xvariable_view.hpp
+++ b/include/xframe/xvariable_view.hpp
@@ -281,7 +281,7 @@ namespace xf
     auto locate(E&& e, S&&... slices);
 
     template <class E, class L = XFRAME_DEFAULT_LABEL_LIST>
-    auto select(E&& e, std::map<typename std::decay_t<E>::key_type, xaxis_slice<L>>&& slices);
+    auto select(E&& e, std::map<typename std::decay_t<E>::key_type, xaxis_slice<L>>&& slices, double tolerance=0.);
 
     template <class E, class T = typename std::decay_t<E>::difference_type>
     auto iselect(E&& e, std::map<typename std::decay_t<E>::key_type, xt::xdynamic_slice<T>>&& slices);
@@ -1089,8 +1089,9 @@ namespace xf
     }
 
     template <class E, class L>
-    inline auto select(E&& e, std::map<typename std::decay_t<E>::key_type, xaxis_slice<L>>&& slices)
+    inline auto select(E&& e, std::map<typename std::decay_t<E>::key_type, xaxis_slice<L>>&& slices, double tolerance)
     {
+        global_tolerance = tolerance;
         using coordinate_type = typename std::decay_t<E>::coordinate_type;
         using dimension_type = typename std::decay_t<E>::dimension_type;
         using dimension_label_list = typename dimension_type::label_list;


### PR DESCRIPTION
I'm just trying to see if I'm at least going in the right direction, so please ignore the hacks for now (global variable...).

The following code:
```cpp
#define XFRAME_DEFAULT_LABEL_LIST xtl::mpl::vector<double, int, std::size_t, char, XFRAME_STRING_LABEL>

#include "xframe/xvariable.hpp"
#include "xframe/xvariable_view.hpp"

int main(int argc, char* argv[])
{
    using coordinate_type = xf::xcoordinate<xf::fstring>;
    using variable_type = xf::xvariable<double, coordinate_type>;
    
    xt::xarray<double> data
          {{1., 2., 3.},
           {4., 5., 6.},
           {7., 8., 9.}};
    
    auto lat = xf::axis({0., -0.1, -0.2});
    auto lon = xf::axis({0., 0.1, 0.2});
    
    auto var = variable_type(
        data,
        {
            {"lat", lat},
            {"lon", lon}
        }
    );

    std::cout << var << std::endl;

    std::cout << xf::select(var, {{"lat", xf::range(0., -0.1)}, {"lon", xf::range(0.11, 0.19)}}, 0.02) << std::endl;

    return 0;
}
```
Produces the following output:
```
{{1, 2, 3},
 {4, 5, 6},
 {7, 8, 9}}
Coordinates:
lat: (0, -0.1, -0.2, )
lon: (0, 0.1, 0.2, )

(2, 3, )
(5, 6, )
Coordinates:
lat: (0, -0.1, )
lon: (0.1, 0.2, )
```